### PR TITLE
Fix `npm run build` for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "postinstall": "typings install",
     "prebuild": "rimraf dist/*",
-    "build": "tsc && dts-generator --exclude 'node_modules/**/*.d.ts' --exclude 'typings/**/*.d.ts' --name posis-api --project ./ --out ./dist/index.d.ts"
+    "build": "tsc && dts-generator --exclude \"node_modules/**/*.d.ts\" --exclude \"typings/**/*.d.ts\" --name posis-api --project ./ --out ./dist/index.d.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Apparantly single quotes don't have the same effect in Windows as they do in Linux.
This works for me on both operating systems.