### PR TITLE
Remove `memory` parameter from SpawnExtension

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -70,7 +70,7 @@ declare const enum EPosisSpawnStatus {
 
 interface IPosisSpawnExtension {
     // Queues/Spawns the creep and returns an ID
-    spawnCreep(rooms: string[], body: string[][], memory?: any, opts?: { priority?: number }): string;
+    spawnCreep(rooms: string[], body: string[][], opts?: { priority?: number }): string;
     // Used to see if its been dropped from queue
     getStatus(id: string): {
         status: EPosisSpawnStatus

--- a/src/extensions/IPosisSpawnExtension.d.ts
+++ b/src/extensions/IPosisSpawnExtension.d.ts
@@ -14,7 +14,7 @@ declare const enum EPosisSpawnStatus {
 
 interface IPosisSpawnExtension {
     // Queues/Spawns the creep and returns an ID
-    spawnCreep(rooms: string[], body: string[][], memory?: any, opts?: { priority?: number }): string;
+    spawnCreep(rooms: string[], body: string[][], opts?: { priority?: number }): string;
     // Used to see if its been dropped from queue
     getStatus(id: string): {
         status: EPosisSpawnStatus


### PR DESCRIPTION
Remove the `memory` parameter from `spawnCreep`. We discussed this in slack a while back, but the change never made it into the repo.

I guess also if we didn't actually come to a conclusion on it, use this thread to argue about why it should be in the standard.