### PR TITLE
defaultStartContext is back!

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5,11 +5,13 @@ type PosisInterfaces = {
 	spawn: IPosisSpawnExtension;
 }
 // Bundle for programs that are logically grouped
-interface IPosisBundle {
+interface IPosisBundle<IDefaultRootMemory> {
+	// host will call that once, possibly outside of main loop, registers all bundle processes here
 	install(registry: IPosisProcessRegistry): void;
-
 	// image name of root process in the bundle, if any
 	rootImageName?: string;
+	// function returning default starting memory for root process, doubles as public parameter documentation
+	defaultRootMemory?: () => IDefaultRootMemory;
 }
 interface IPosisExtension {}
 interface IPosisKernel extends IPosisExtension {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5,13 +5,13 @@ type PosisInterfaces = {
 	spawn: IPosisSpawnExtension;
 }
 // Bundle for programs that are logically grouped
-interface IPosisBundle<IDefaultRootMemory> {
+interface IPosisBundle<IDefaultRootMemory, IDefaultRootMemoryOverride> {
 	// host will call that once, possibly outside of main loop, registers all bundle processes here
 	install(registry: IPosisProcessRegistry): void;
 	// image name of root process in the bundle, if any
 	rootImageName?: string;
 	// function returning default starting memory for root process, doubles as public parameter documentation
-	makeDefaultRootMemory?: (override?: IDefaultRootMemory) => IDefaultRootMemory;
+	makeDefaultRootMemory?: (override?: IDefaultRootMemoryOverride) => IDefaultRootMemory;
 }
 interface IPosisExtension {}
 interface IPosisKernel extends IPosisExtension {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -11,7 +11,7 @@ interface IPosisBundle<IDefaultRootMemory> {
 	// image name of root process in the bundle, if any
 	rootImageName?: string;
 	// function returning default starting memory for root process, doubles as public parameter documentation
-	defaultRootMemory?: () => IDefaultRootMemory;
+	makeDefaultRootMemory?: (override?: IDefaultRootMemory) => IDefaultRootMemory;
 }
 interface IPosisExtension {}
 interface IPosisKernel extends IPosisExtension {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5,13 +5,13 @@ type PosisInterfaces = {
 	spawn: IPosisSpawnExtension;
 }
 // Bundle for programs that are logically grouped
-interface IPosisBundle<IDefaultRootMemory, IDefaultRootMemoryOverride> {
+interface IPosisBundle<IDefaultRootMemory> {
 	// host will call that once, possibly outside of main loop, registers all bundle processes here
 	install(registry: IPosisProcessRegistry): void;
 	// image name of root process in the bundle, if any
 	rootImageName?: string;
 	// function returning default starting memory for root process, doubles as public parameter documentation
-	makeDefaultRootMemory?: (override?: IDefaultRootMemoryOverride) => IDefaultRootMemory;
+	makeDefaultRootMemory?: (override?: IDefaultRootMemory) => IDefaultRootMemory;
 }
 interface IPosisExtension {}
 interface IPosisKernel extends IPosisExtension {

--- a/src/core/IPosisBundle.d.ts
+++ b/src/core/IPosisBundle.d.ts
@@ -1,9 +1,9 @@
 // Bundle for programs that are logically grouped
-interface IPosisBundle<IDefaultRootMemory, IDefaultRootMemoryOverride> {
+interface IPosisBundle<IDefaultRootMemory> {
 	// host will call that once, possibly outside of main loop, registers all bundle processes here
 	install(registry: IPosisProcessRegistry): void;
 	// image name of root process in the bundle, if any
 	rootImageName?: string;
 	// function returning default starting memory for root process, doubles as public parameter documentation
-	makeDefaultRootMemory?: (override?: IDefaultRootMemoryOverride) => IDefaultRootMemory;
+	makeDefaultRootMemory?: (override?: IDefaultRootMemory) => IDefaultRootMemory;
 }

--- a/src/core/IPosisBundle.d.ts
+++ b/src/core/IPosisBundle.d.ts
@@ -1,9 +1,9 @@
 // Bundle for programs that are logically grouped
-interface IPosisBundle<IDefaultRootMemory> {
+interface IPosisBundle<IDefaultRootMemory, IDefaultRootMemoryOverride> {
 	// host will call that once, possibly outside of main loop, registers all bundle processes here
 	install(registry: IPosisProcessRegistry): void;
 	// image name of root process in the bundle, if any
 	rootImageName?: string;
 	// function returning default starting memory for root process, doubles as public parameter documentation
-	defaultRootMemory?: () => IDefaultRootMemory;
+	makeDefaultRootMemory?: (override?: IDefaultRootMemoryOverride) => IDefaultRootMemory;
 }

--- a/src/core/IPosisBundle.d.ts
+++ b/src/core/IPosisBundle.d.ts
@@ -1,7 +1,9 @@
 // Bundle for programs that are logically grouped
-interface IPosisBundle {
+interface IPosisBundle<IDefaultRootMemory> {
+	// host will call that once, possibly outside of main loop, registers all bundle processes here
 	install(registry: IPosisProcessRegistry): void;
-
 	// image name of root process in the bundle, if any
 	rootImageName?: string;
+	// function returning default starting memory for root process, doubles as public parameter documentation
+	defaultRootMemory?: () => IDefaultRootMemory;
 }


### PR DESCRIPTION
See recent slack for more context.

Rationale is to allow explicit specification of root process (the only public facing process normally) to specify both its public parameters and default values for those.

Wrapped it into a function so that a host not using them is not paying the cost.

Example implementation:
```typescript
export const bundle: IPosisBundle<IRamparterPublicParameters> =
{
	install(registry: IPosisProcessRegistry)
	{
		registry.register(Ramparter.ImageName, Ramparter);
	},
	rootImageName: Ramparter.ImageName,
	makeDefaultRootMemory(override: IRamparterPublicParameters)
	{
		const mem: IRamparterPublicParameters = _.merge(
		{
			constructionSiteBudget: 10,
			sleepFor: 10,
			structureTypes: [ STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_STORAGE, STRUCTURE_TERMINAL ],
		}, override);

		// here we pretend this is an expensive operation that is worth avoiding if host already provided the value
		if (mem.rooms === undefined)
			mem.rooms = _.compact(_.map<any, any>(Game.rooms, (r) => r.controller && r.controller.my ? r.name.toString() : undefined));

		return mem;
	},
};
```

And usage in host when importing the bundle:
![image](https://user-images.githubusercontent.com/1617834/27525535-e405adfc-59fb-11e7-8af5-80680ff42eaa.png)

I'm not entirely happy with it, so suggestions for better typing are welcome.