### PR TITLE
Changed spawnProcess to return pid and process

### DIFF
--- a/src/core/IPosisKernel.d.ts
+++ b/src/core/IPosisKernel.d.ts
@@ -1,5 +1,5 @@
 interface IPosisKernel extends IPosisExtension {
-    startProcess(imageName: string, startContext: any): IPosisProcess | undefined;
+    startProcess(imageName: string, startContext: any): { pid: PosisPID; process: IPosisProcess } | undefined;
     // killProcess also kills all children of this process
     // note to the wise: probably absorb any calls to this that would wipe out your entire process tree.
     killProcess(pid: PosisPID): void;


### PR DESCRIPTION
This change makes spawnProcess return `{ pid: PosisPID, process: IPosisProcess }` as discussed on slack, this gets around the issue of IPosisProcess no longer exposing PID