### PR TITLE
Minor PosisInterfaces Tweak

### DIFF
--- a/src/core/globals.d.ts
+++ b/src/core/globals.d.ts
@@ -1,6 +1,6 @@
 type PosisPID = string | number;
 
-type PosisInterfaces = {
+interface PosisInterfaces {
 	baseKernel: IPosisKernel;
 	spawn: IPosisSpawnExtension;
 }


### PR DESCRIPTION
Changes PosisInterfaces from `type` to `interface` to allow ambient extension